### PR TITLE
Function_library from script_tools used by default

### DIFF
--- a/update_wiringpi.sh
+++ b/update_wiringpi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /home/pi/di_update/Raspbian_For_Robots/upd_script/functions_library.sh
+source /home/pi/Dexter/lib/Dexter/script_tools/functions_library.sh
 
 PIHOME=/home/pi
 DEXTER=Dexter


### PR DESCRIPTION
- DI update function_library looks older
- using script_tools makes it work in standalone installations too