### PR TITLE
module for auto-detecting [rpi model]

### DIFF
--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -1,0 +1,121 @@
+'''
+## License
+
+The MIT License (MIT)
+
+GrovePi for the Raspberry Pi: an open source platform for connecting Grove Sensors to the Raspberry Pi.
+Copyright (C) 2017  Dexter Industries
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+'''
+
+import subprocess
+
+# RPI_VARIANTS was inspired from http://www.raspberrypi-spy.co.uk/2012/09/checking-your-raspberry-pi-board-version/
+# This module is meant for retrieving the Raspberry Pi's generation model, PCB model (dimension-wise) and PCB revision
+# Works with Python 3 & 2 !!!
+
+# Each key represents the hardware revision number
+# This isn't the same as the RaspberryPi revision
+# Having the hardware revision number is useful when working with hardware or software.
+
+RPI_VARIANTS = {
+"0002" : ["Model B Rev 1", "RPI1"],
+
+"0003" : ["Model B Rev 1 ECN0001 (no fuses, D14 removed)", "RPI1"],
+
+"0004" : ["Model B Rev 2", "RPI1"],
+"0005" : ["Model B Rev 2", "RPI1"],
+"0006" : ["Model B Rev 2", "RPI1"],
+
+"0007" : ["Model A", "RPI1"],
+"0008" : ["Model A", "RPI1"],
+"0009" : ["Model A", "RPI1"],
+
+"000d" : ["Model B Rev 2", "RPI1"],
+"000e" : ["Model B Rev 2", "RPI1"],
+"000f" : ["Model B Rev 2", "RPI1"],
+
+"0010" : ["Model B+", "RPI1"],
+"0013" : ["Model B+", "RPI1"],
+"900032" : ["Model B+", "RPI1"],
+
+"0011" : ["Compute Module", "RPI-COMPUTE-MODULE"],
+"0014" : ["Compute Module", "RPI-COMPUTE-MODULE"],
+
+"0012" : ["Model A+", "RPI1"],
+"0015" : ["Model A+", "RPI1"],
+
+"a01041" : ["Pi 2 Model B v1.1", "RPI2"],
+"a21041" : ["Pi 2 Model B v1.1", "RPI2"],
+
+"a22042" : ["Pi 2 Model B v1.2", "RPI2"],
+
+"900092" : ["Pi Zero v1.2", "RPI0"],
+
+"900093" : ["Pi Zero v1.3", "RPI0"],
+
+"0x9000C1" : ["Pi Zero W", "RPI0"],
+
+"a02082" : ["Pi 3 Model B", "RPI3"],
+"a22082" : ["Pi 3 Model B", "RPI3"],
+}
+
+# represents indexes for each corresponding key in the above dictionary
+RPI_MODEL_AND_PCBREV = 0
+RPI_GENERATION_MODEL = 1
+
+# returns slightly more descriptive information on the hardware revision of the Raspberry Pi
+# e.g. "Pi 2 Model B v1.1" etc
+def getRPIHardwareRevCode():
+    bash_command = "sudo cat /proc/cpuinfo | grep Revision | awk '{print $3}'"
+    revision = sendBashCommand(bash_command)
+    rpi_description = ""
+
+    # if stdout has something
+    if not revision is None:
+        rpi_description = RPI_VARIANTS[revision][RPI_MODEL_AND_PCBREV]
+
+    return rpi_description
+
+# returns the Raspberry Pi's generation Model
+# e.g. "RPI2", "RPI3" etc
+def getRPIGenerationCode():
+
+    bash_command = "sudo cat /proc/cpuinfo | grep Revision | awk '{print $3}'"
+    revision = sendBashCommand(bash_command)
+    rpi_description = ""
+
+    # if stdout has something
+    if not revision is None:
+        rpi_description = RPI_VARIANTS[revision][RPI_GENERATION_MODEL]
+
+    return rpi_description
+
+# takes a string of commands and spawns commands inside linux's environment
+# and returns the output of that process, if provided
+def sendBashCommand(bash_command)
+
+	process = subprocess.Popen(bash_command.split(), stdout = subprocess.PIPE)
+
+    # use communicate to read data from stdout - index 0 is for stdout and 1 is for stderr
+    # don't use this function if the data size is large or unlimited
+    # useeful when trying to avoid deadlocks
+	output = process.communicate()[0]
+	return output

--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -81,10 +81,10 @@ RPI_GENERATION_MODEL = 1
 
 def getRPIHardwareRevCode():
     """
-    Returns slightly more descriptive information on the hardware revision of the Raspberry Pi.
-    If it can't find anything, it returns "NOT_FOUND"
-    If there's an error while reading the file, it returns a None
-    Examples of strings returned : "Model B Rev 2", "Model A+", "Pi 3 Model B", etc
+    Returns the hardware revision of the Raspberry Pi.
+    If it can't find anything, it returns "NOT_FOUND".
+    If there's an error while reading the file, it returns a None.
+    Examples of strings returned : "Model B Rev 2", "Model A+", "Pi 3 Model B", etc.
     Look into the dictionary to see all the possible variants.
     """
     cpuinfo_lines = readLinesFromFile("/proc/cpuinfo")
@@ -105,8 +105,8 @@ def getRPIHardwareRevCode():
 def getRPIGenerationCode():
     """
     Returns the Raspberry Pi's generation model.
-    If it can't find anything, it returns "NOT_FOUND"
-    If there's an error while reading the file, it returns a None
+    If it can't find anything, it returns "NOT_FOUND".
+    If there's an error while reading the file, it returns a None.
     Depending on the Raspberry Pi's model, the function can return the following strings:
     "RPI0"
     "RPI1"

--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -81,9 +81,13 @@ RPI_VARIANTS = {
 RPI_MODEL_AND_PCBREV = 0
 RPI_GENERATION_MODEL = 1
 
-# returns slightly more descriptive information on the hardware revision of the Raspberry Pi
-# e.g. "Pi 2 Model B v1.1" etc
 def getRPIHardwareRevCode():
+    """
+    Returns slightly more descriptive information on the hardware revision of the Raspberry Pi
+    Examples of strings returned : "Model B Rev 2", "Model A+", "Pi 3 Model B", etc
+    Look into the dictionary to see all the possible variants
+    """
+
     bash_command = "sudo cat /proc/cpuinfo | grep Revision | awk '{print $3}'"
     revision = sendBashCommand(bash_command)
     rpi_description = ""
@@ -94,9 +98,16 @@ def getRPIHardwareRevCode():
 
     return rpi_description
 
-# returns the Raspberry Pi's generation Model
-# e.g. "RPI2", "RPI3" etc
 def getRPIGenerationCode():
+    """
+    Returns the Raspberry Pi's generation model
+    Depending on the Raspberry Pi's model, the function can return the following strings:
+    "RPI0"
+    "RPI1"
+    "RPi2"
+    "RPI3"
+    "RPI-COMPUTE-MODULE"
+    """
 
     bash_command = "sudo cat /proc/cpuinfo | grep Revision | awk '{print $3}'"
     revision = sendBashCommand(bash_command)
@@ -108,9 +119,11 @@ def getRPIGenerationCode():
 
     return rpi_description
 
-# takes a string of commands and spawns commands inside linux's environment
-# and returns the output of that process, if provided
-def sendBashCommand(bash_command)
+def sendBashCommand(bash_command):
+    """
+    Takes a string of commands and spawns commands inside linux's environment.
+    Returns the stdout of that process, if provided, otherwise None is returned
+    """
 
 	process = subprocess.Popen(bash_command.split(), stdout = subprocess.PIPE)
 

--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -82,6 +82,8 @@ RPI_GENERATION_MODEL = 1
 def getRPIHardwareRevCode():
     """
     Returns slightly more descriptive information on the hardware revision of the Raspberry Pi.
+    If it can't find anything, it returns "NOT_FOUND"
+    If there's an error while reading the file, it returns a None
     Examples of strings returned : "Model B Rev 2", "Model A+", "Pi 3 Model B", etc
     Look into the dictionary to see all the possible variants.
     """
@@ -92,13 +94,19 @@ def getRPIHardwareRevCode():
         revision_line = cpuinfo_lines[-2]
         revision = revision_line.split(":")[-1]
         revision = revision.strip()
-        rpi_description = RPI_VARIANTS[revision][RPI_MODEL_AND_PCBREV]
+
+        if revision in RPI_VARIANTS.keys():
+            rpi_description = RPI_VARIANTS[revision][RPI_MODEL_AND_PCBREV]
+        else:
+            rpi_description = "NOT_FOUND"
 
     return rpi_description
 
 def getRPIGenerationCode():
     """
     Returns the Raspberry Pi's generation model.
+    If it can't find anything, it returns "NOT_FOUND"
+    If there's an error while reading the file, it returns a None
     Depending on the Raspberry Pi's model, the function can return the following strings:
     "RPI0"
     "RPI1"
@@ -114,7 +122,11 @@ def getRPIGenerationCode():
         revision_line = cpuinfo_lines[-2]
         revision = revision_line.split(":")[-1]
         revision = revision.strip()
-        rpi_description = RPI_VARIANTS[revision][RPI_GENERATION_MODEL]
+
+        if revision in RPI_VARIANTS.keys():
+            rpi_description = RPI_VARIANTS[revision][RPI_GENERATION_MODEL]
+        else:
+            rpi_description = "NOT_FOUND"
 
     return rpi_description
 

--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -89,10 +89,10 @@ def getRPIHardwareRevCode():
     rpi_description = ""
 
     if not cpuinfo_lines is None:
-        serial_line = cpuinfo_lines[-1]
-        serial = serial_line.split(":")[-1]
-        serial = serial.rstrip()
-        rpi_description = RPI_VARIANTS[serial][RPI_MODEL_AND_PCBREV]
+        revision_line = cpuinfo_lines[-2]
+        revision = revision_line.split(":")[-1]
+        revision = revision.rstrip()
+        rpi_description = RPI_VARIANTS[revision][RPI_MODEL_AND_PCBREV]
 
     return rpi_description
 
@@ -111,10 +111,10 @@ def getRPIGenerationCode():
     rpi_description = ""
 
     if not cpuinfo_lines is None:
-        serial_line = cpuinfo_lines[-1]
-        serial = serial_line.split(":")[-1]
-        serial = serial.rstrip()
-        rpi_description = RPI_VARIANTS[serial][RPI_GENERATION_MODEL]
+        revision_line = cpuinfo_lines[-2]
+        revision = revision_line.split(":")[-1]
+        revision = revision.rstrip()
+        rpi_description = RPI_VARIANTS[revision][RPI_GENERATION_MODEL]
 
     return rpi_description
 

--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -91,7 +91,7 @@ def getRPIHardwareRevCode():
     if not cpuinfo_lines is None:
         revision_line = cpuinfo_lines[-2]
         revision = revision_line.split(":")[-1]
-        revision = revision.rstrip()
+        revision = revision.strip()
         rpi_description = RPI_VARIANTS[revision][RPI_MODEL_AND_PCBREV]
 
     return rpi_description
@@ -113,7 +113,7 @@ def getRPIGenerationCode():
     if not cpuinfo_lines is None:
         revision_line = cpuinfo_lines[-2]
         revision = revision_line.split(":")[-1]
-        revision = revision.rstrip()
+        revision = revision.strip()
         rpi_description = RPI_VARIANTS[revision][RPI_GENERATION_MODEL]
 
     return rpi_description

--- a/autodetect_setup.py
+++ b/autodetect_setup.py
@@ -27,6 +27,6 @@ setuptools.setup(
 	description="Dexter Industries Robot Autodetection",
 	author="Dexter Industries",
 	url="http://www.dexterindustries.com/GoPiGo/",
-	py_modules=['auto_detect_robot'],
+	py_modules=['auto_detect_robot', 'auto_detect_rpi'],
 	#install_requires=open('requirements.txt').readlines(),
 )


### PR DESCRIPTION
I've created the `auto_detect_rpi` Python module.
We now can use this module for detecting the `Raspberry Pi` version.

This module has 3 basic functions (one of which is utilitarian) :

-  `getRPIHardwareRevCode()` - with this function we get the revision that's written onto the PCB board.

- `getRPIGenerationCode()` - with this function we get the Raspberry Pi generation model - like `RPI1` or say `RPI3`.

- `sendBashCommand()` - function which ***shouldn't*** be placed here and does exactly what it says. It shouldn't be here, because this module name's is not a match with what this function does. I left here because these mods would require agreements / discussions within our team.

---------

Tests' priorities:

- [x] Test this functionality by author.

- [ ] Test this functionality by team.