### PR TITLE
hotfix - fixed issue with identifying rpi zero w

### DIFF
--- a/auto_detect_rpi.py
+++ b/auto_detect_rpi.py
@@ -69,7 +69,7 @@ RPI_VARIANTS = {
 
 "900093" : ["Pi Zero v1.3", "RPI0"],
 
-"0x9000C1" : ["Pi Zero W", "RPI0"],
+"9000C1" : ["Pi Zero W", "RPI0"],
 
 "a02082" : ["Pi 3 Model B", "RPI3"],
 "a22082" : ["Pi 3 Model B", "RPI3"],


### PR DESCRIPTION
RPi Zero W couldn't be identified - there was a typo in there that prevented it from being detected
Bug reported here: https://forum.dexterindustries.com/t/raspberry-pi-zero-w-and-pivotpi/3862/10?u=robertlucian