### PR TITLE
Doing a chmod here could lead to endless loops if permissions are wrong

### DIFF
--- a/I2C_mutex.py
+++ b/I2C_mutex.py
@@ -29,7 +29,6 @@ class Mutex(object):
         while not acquired:
             try:
                 self.DexterLockI2C_handle = open(self.DexterLockI2C_handle_filename, 'w')
-                os.chmod(self.DexterLockI2C_handle_filename, 0o777)
                 # lock
                 fcntl.lockf(self.DexterLockI2C_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True


### PR DESCRIPTION
While this situation would most likely not happen in the context of DexterOS, it can happen when you run manual tests. 