### PR TITLE
fix - make new changes to script_tools update-able

### DIFF
--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -49,6 +49,7 @@ fi
 
 cd $PIHOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
 sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
+sudo rm -rf *.egg-info build dist
 python setup.py install
 python3 setup.py install
 


### PR DESCRIPTION
The reason the [RemoteCameraProject](https://github.com/DexterInd/GoPiGo3/tree/master/Projects/RemoteCameraRobot) no longer works is because the new `I2C_mutex` isn't installed with script_tools due to build outputs that exist in the repo's directory. Removing these builds makes it work again.

The issue was reported here:
https://forum.dexterindustries.com/t/remotecamerarobot-not-working/4177/12

-> _I need to double-check this to be 100% sure_.