### PR TITLE
feature - arg based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ curl -kL dexterindustries.com/update_tools | bash
 
 The above command installs the python package with user-level permissions on the system-wide environment - which does not work on most distributions unless a virtual environment is used.
 
+### Python Package Options
+
+In order to **enable the installation of the python package**, option `--install-python-package` is a must. This holds true for both python executables (`python` and `python3`) in case you are wondering if this is for `--use-python3-exe-too`.
+
 The options for the python package that can be appended to this command are (all these 3 options **are mutually exclusive**):
 
 * `--system-wide` - uses `sudo` for installing the python package system-wide.
@@ -18,12 +22,16 @@ The options for the python package that can be appended to this command are (all
 
 * `--env-local` - for installing the python package system-wide, but without any special write/read/execute permissions - in order to use this you'll need a virtual environment.
 
-On different distributions, Python 3 can only be used with `python3` command, in which case option `--use-python3-command-too` is required.
+On different distributions, Python 3 can only be used with `python3` executable, in which case option `--use-python3-exe-too` is required.
+
+### Apt-Get Package Options
 
 The options that can be added for apt-get/deb packages are:
 
 * `update-aptget` - will run `sudo apt-get update`.
 * `--install-deb-debs` - will run the `sudo apt-get install [dependencies]` command which installs the general dependencies.
+
+### Selecting a Branch/Tag to Checkout
 
 Also, to this install script you can specify a tag or a branch you want to use, just by passing the name of it. Branches must have this format (`master`, `develop`, `feature/*`, `hotfix/*`, `fix/`) whereas tags can have this format (`v*` or `DexterOS*`).
 **By default, `master` branch is pulled.**
@@ -32,20 +40,20 @@ Also, to this install script you can specify a tag or a branch you want to use, 
 
 To install the python package with `sudo` and skip installing apt-get packages (though in this case `--system-wide` can be omitted because it's turned on by default):
 ```
-curl -kL dexterindustries.com/update_tools | bash -s --system-wide
+curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --system-wide
 ```
 
 To install the python package locally in the home directory and skip installing apt-get packages:
 ```
-curl -kL dexterindustries.com/update_tools | bash -s --user-local
+curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --user-local
 ```
 
 To install the python package locally in the home directory, run apt-get update and install apt-get dependencies:
 ```
-curl -kL dexterindustries.com/update_tools | bash -s --user-local --update-aptget --install-deb-deps
+curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --user-local --update-aptget --install-deb-deps
 ```
 
-To install the python package system-wide and take the version that's pointed by tag `DexterOS2.0`:
+To only install `script_tools` at the designated location without installing the python package and take the version that's pointed by tag `DexterOS2.0`:
 ```
 curl -kL dexterindustries.com/update_tools | bash -s DexterOS2.0
 ```
@@ -55,7 +63,7 @@ curl -kL dexterindustries.com/update_tools | bash -s develop
 ```
 To install packages for `python` and `python3` executables/commands, you can do this:
 ```
-curl -kL dexterindustries.com/update_tools | bash -s --use-python3-command-too
+curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --use-python3-exe-too
 ```
 
 # Updating

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The options for the python package that can be appended to this command are (all
 
 * `--env-local` - for installing the python package system-wide, but without any special write/read/execute permissions - in order to use this you'll need a virtual environment.
 
+On different distributions, Python 3 can only be used with `python3` command, in which case option `--use-python3-command-too` is required.
+
 The options that can be added for apt-get/deb packages are:
 
 * `update-aptget` - will run `sudo apt-get update`.
@@ -50,6 +52,10 @@ curl -kL dexterindustries.com/update_tools | bash -s DexterOS2.0
 Or if we want the version that's on `develop` branch we can do:
 ```
 curl -kL dexterindustries.com/update_tools | bash -s develop
+```
+To install packages for `python` and `python3` executables/commands, you can do this:
+```
+curl -kL dexterindustries.com/update_tools | bash -s --use-python3-command-too
 ```
 
 # Updating

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Common installation scripts used in multiple products around the Dexter Industri
 
 The most basic command used for updating/installing script_tools can be:
 ```
-curl -kL dexterindustries.com/update_tools | bash
+curl -kL dexterindustries.com/update_tools | bash -s --install-python-package
 ```
 
 The above command installs the python package with user-level permissions on the system-wide environment - which does not work on most distributions unless a virtual environment is used.

--- a/README.md
+++ b/README.md
@@ -55,22 +55,3 @@ curl -kL dexterindustries.com/update_tools | bash -s develop
 # Updating
 
 For updating the package, you can use the same commands describe at the previous section.
-
---user-local)
-  userlocal=true
-  systemwide=false
-  ;;
---env-local)
-  envlocal=true
-  systemwide=false
-  ;;
---system-wide)
-  ;;
---update-aptget)
-  updatedebs=true
-  ;;
---just-install-deb-deps)
-  installdebs=true
-  ;;
-develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
-  selectedbranch="$i"

--- a/README.md
+++ b/README.md
@@ -3,16 +3,74 @@ Common installation scripts used in multiple products around the Dexter Industri
 
 # Installing
 
-For installing the python packages of `script_tools` with root privileges (except for anything else than comes with it), use the following command:
-```
-sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
-```
-
-For installing the python packages of `script_tools` without root privileges (except for anything else than comes with it), use the following command:
+The most basic command used for updating/installing script_tools can be:
 ```
 curl -kL dexterindustries.com/update_tools | bash
+```
+
+The above command installs the python package with user-level permissions on the system-wide environment - which does not work on most distributions unless a virtual environment is used.
+
+The options for the python package that can be appended to this command are (all these 3 options **are mutually exclusive**):
+
+* `--system-wide` - uses `sudo` for installing the python package system-wide.
+
+* `--user-local` - for installing the python package in the home directory of the given user, where no special write/read/execute permissions are required.
+
+* `--env-local` - for installing the python package system-wide, but without any special write/read/execute permissions - in order to use this you'll need a virtual environment.
+
+The options that can be added for apt-get/deb packages are:
+
+* `update-aptget` - will run `sudo apt-get update`.
+* `--install-deb-debs` - will run the `sudo apt-get install [dependencies]` command which installs the general dependencies.
+
+Also, to this install script you can specify a tag or a branch you want to use, just by passing the name of it. Branches must have this format (`master`, `develop`, `feature/*`, `hotfix/*`, `fix/`) whereas tags can have this format (`v*` or `DexterOS*`).
+**By default, `master` branch is pulled.**
+
+# Installation Examples
+
+To install the python package with `sudo` and skip installing apt-get packages (though in this case `--system-wide` can be omitted because it's turned on by default):
+```
+curl -kL dexterindustries.com/update_tools | bash -s --system-wide
+```
+
+To install the python package locally in the home directory and skip installing apt-get packages:
+```
+curl -kL dexterindustries.com/update_tools | bash -s --user-local
+```
+
+To install the python package locally in the home directory, run apt-get update and install apt-get dependencies:
+```
+curl -kL dexterindustries.com/update_tools | bash -s --user-local --update-aptget --install-deb-deps
+```
+
+To install the python package system-wide and take the version that's pointed by tag `DexterOS2.0`:
+```
+curl -kL dexterindustries.com/update_tools | bash -s DexterOS2.0
+```
+Or if we want the version that's on `develop` branch we can do:
+```
+curl -kL dexterindustries.com/update_tools | bash -s develop
 ```
 
 # Updating
 
 For updating the package, you can use the same commands describe at the previous section.
+
+--user-local)
+  userlocal=true
+  systemwide=false
+  ;;
+--env-local)
+  envlocal=true
+  systemwide=false
+  ;;
+--system-wide)
+  ;;
+--update-aptget)
+  updatedebs=true
+  ;;
+--just-install-deb-deps)
+  installdebs=true
+  ;;
+develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
+  selectedbranch="$i"

--- a/functions_library.sh
+++ b/functions_library.sh
@@ -137,6 +137,22 @@ who_called_me() {
   echo ${BASH_SOURCE[1]}
 }
 
+check_internet() {
+    # check if there's internet access
+    # and if there's not, exit the script
+    if ! quiet_mode ; then
+        feedback "Check for internet connectivity..."
+        feedback "=================================="
+        wget -q --tries=2 --timeout=20 --output-document=/dev/null https://raspberrypi.org
+        if [ $? -eq 0 ];then
+            echo "Connected to the Internet"
+        else
+            echo "Unable to Connect, try again !!!"
+            exit 0
+        fi
+    fi
+}
+
 #########################################################################
 #
 #  FILE EDITION

--- a/functions_library.sh
+++ b/functions_library.sh
@@ -312,14 +312,14 @@ wget_file() {
 create_folder(){
   if ! folder_exists "$1"
   then
-    sudo mkdir "$1"
+    sudo mkdir -p "$1"
   fi
 }
 
 create_folder_nosudo(){
   if ! folder_exists "$1"
   then
-    mkdir "$1"
+    mkdir -p "$1"
   fi
 }
 

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -8,6 +8,9 @@
 #####################################################################
 #####################################################################
 
+command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Aborting." >&2; exit 1; }
+command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Aborting." >&2; exit 2; }
+
 # the following 3 options are mutually exclusive
 systemwide=true
 userlocal=false
@@ -49,10 +52,8 @@ for i; do
   esac
 done
 
-echo $systemwide
-echo $userlocal
-echo $envlocal
-echo $selectedbranch
+if $usepython3exec; then
+  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
 
 DEXTER=Dexter
 LIB=lib
@@ -76,13 +77,13 @@ current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 
 cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
 
-[[ $updatedebs ]] && sudo apt-get update
-[[ $installdebs ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
-[[ $systemwide ]] && sudo python setup.py install --force \
-                  && [[ $usepython3exec ]] && sudo python3 setup.py install --force
-[[ $userlocal ]] && python setup.py install --force --user \
-                  && [[ $usepython3exec ]] && python3 setup.py install --force --user
-[[ $envlocal ]] && python setup.py install --force \
-                  && [[ $usepython3exec ]] && python3 setup.py install --force
+$updatedebs && sudo apt-get update
+$installdebs && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
+$systemwide && sudo python setup.py install --force \
+            && $usepython3exec && sudo python3 setup.py install --force
+$userlocal && python setup.py install --force --user \
+            && $usepython3exec && python3 setup.py install --force --user
+$envlocal && python setup.py install --force \
+            && $usepython3exec && python3 setup.py install --force
 
 popd > /dev/null

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -52,7 +52,7 @@ for i; do
   esac
 done
 
-if $usepython3exec; then
+if [[ $usepython3exec = "true" ]]; then
   command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
 
 DEXTER=Dexter
@@ -77,13 +77,14 @@ current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 
 cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
 
-$updatedebs && sudo apt-get update
-$installdebs && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
-$systemwide && sudo python setup.py install --force \
-            && $usepython3exec && sudo python3 setup.py install --force
-$userlocal && python setup.py install --force --user \
-            && $usepython3exec && python3 setup.py install --force --user
-$envlocal && python setup.py install --force \
-            && $usepython3exec && python3 setup.py install --force
+[[ $updatedebs = "true" ]] && sudo apt-get update
+[[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
+
+[[ $systemwide = "true" ]] && sudo python setup.py install --force \
+            && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
+[[ $userlocal = "true" ]] && python setup.py install --force --user \
+            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user
+[[ $envlocal = "true" ]] && python setup.py install --force \
+            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force
 
 popd > /dev/null

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -97,6 +97,8 @@ parse_cmdline_arguments() {
   echo "--install-deb-deps=$installdebs"
 
   # create folders recursively if they don't exist already
+  # can't use <<functions_library.sh>> here because there's no
+  # cloned script_tools yet at this part of the install script
   sudo mkdir -p $DEXTER_PATH
   sudo chown pi:pi -R $PIHOME/$DEXTER
   popd > /dev/null

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -36,7 +36,7 @@ for i; do
     --update-aptget)
       updatedebs=true
       ;;
-    --just-install-deb-deps)
+    --install-deb-deps)
       installdebs=true
       ;;
     develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -12,6 +12,15 @@ DEXTER_PATH=$PIHOME/$DEXTER/$LIB/$DEXTER
 DEXTER_SCRIPT=$DEXTER_PATH/script_tools
 REPO_PACKAGE=dexter-autodetection-and-i2c-mutex
 
+# called way down bellow
+check_if_run_with_pi() {
+  ## if not running with the pi user then exit
+  if [ $(id -ur) -ne $(id -ur pi) ]; then
+    echo "GoPiGo3 installer script must be run with \"pi\" user. Exiting."
+    exit 4
+  fi
+}
+
 parse_cmdline_arguments() {
   # the following option is required should the python package be installed
   # by default, the python package are not installed
@@ -200,6 +209,7 @@ install_python_package() {
 ######## Aggregating all function calls ########
 ################################################
 
+check_if_run_with_pi
 parse_cmdline_arguments "$@"
 install_dependencies
 clone_scriptools

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -200,7 +200,7 @@ install_python_package() {
 ######## Aggregating all function calls ########
 ################################################
 
-parse_cmdline_arguments
+parse_cmdline_arguments "$@"
 install_dependencies
 clone_scriptools
 install_python_package

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -54,6 +54,7 @@ done
 
 if [[ $usepython3exec = "true" ]]; then
   command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
+fi
 
 DEXTER=Dexter
 LIB=lib

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -57,32 +57,10 @@ SCRIPT=script_tools
 pushd $HOME > /dev/null
 result=${PWD##*/}
 
-echo $result
+echo "Current directory is \"$result\""
 
-# check if ~/Dexter exists, if not create it
-if [ ! -d $DEXTER ] ; then
-    mkdir $DEXTER
-fi
-# go into $DEXTER
-cd $PIHOME/$DEXTER
-
-
-# check if /home/pi/Dexter/lib exists, if not create it
-if [ ! -d $LIB ] ; then
-    mkdir $LIB
-fi
-cd $HOME/$DEXTER/$LIB
-
-# check if /home/pi/Dexter/lib/Dexter exists, if not create it
-if [ ! -d $DEXTER ] ; then
-    mkdir $DEXTER
-fi
-cd $HOME/$DEXTER/$LIB/$DEXTER
-
-
-# check if /home/pi/Dexter/lib/script_tools exists
-# if yes refresh the folder
-# if not, clone the folder
+# create folders recursively if they don't exist already
+mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
 
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -5,140 +5,201 @@
 ################################################
 
 OS_CODENAME=$(lsb_release --codename --short)
-
-# the following option is required should the python package be installed
-# by default, the python package are not installed
-installpythonpkg=false
-
-# the following 3 options are mutually exclusive
-systemwide=true
-userlocal=false
-envlocal=false
-usepython3exec=false
-
-# the following 2 options can be used together
-updatedebs=false
-installdebs=false
-
-# the following option tells which branch has to be used
-selectedbranch="master" # set to master by default
-
-# iterate through bash arguments
-for i; do
-  case "$i" in
-    --install-python-package)
-      installpythonpkg=true
-      ;;
-    --user-local)
-      userlocal=true
-      systemwide=false
-      ;;
-    --env-local)
-      envlocal=true
-      systemwide=false
-      ;;
-    --system-wide)
-      ;;
-    --update-aptget)
-      updatedebs=true
-      ;;
-    --install-deb-deps)
-      installdebs=true
-      ;;
-    --use-python3-exe-too)
-      usepython3exec=true
-      ;;
-    develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
-      selectedbranch="$i"
-      ;;
-  esac
-done
-
-
-# exit if git is not installed
-if [[ $installdebs = "false" ]]; then
-  command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Use \"--install-deb-deps\" option. Aborting." >&2; exit 1; }
-fi
-
-# exit if python/python3 are not installed in the current environment
-if [[ $installpythonpkg = "true" ]]; then
-  command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Aborting." >&2; exit 2; }
-  if [[ $usepython3exec = "true" ]]; then
-    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
-  fi
-fi
-
+PIHOME=/home/pi
 DEXTER=Dexter
 LIB=lib
-SCRIPT=script_tools
+DEXTER_PATH=$HOME/$DEXTER/$LIB/$DEXTER
+DEXTER_SCRIPT=$DEXTER_PATH/script_tools
+REPO_PACKAGE=dexter-autodetection-and-i2c-mutex
 
-pushd $HOME > /dev/null
-result=${PWD##*/}
+parse_cmdline_arguments() {
+  # the following option is required should the python package be installed
+  # by default, the python package are not installed
+  installpythonpkg=false
 
-echo "Updating script_tools for $selectedbranch branch with the following options:"
-echo "--install-python-package=$installpythonpkg"
-echo "--system-wide=$systemwide"
-echo "--user-local=$userlocal"
-echo "--env-local=$envlocal"
-echo "--use-python3-exe-too=$usepython3exec"
-echo "--update-aptget=$updatedebs"
-echo "--install-deb-deps=$installdebs"
+  # the following 3 options are mutually exclusive
+  systemwide=true
+  userlocal=false
+  envlocal=false
+  usepython3exec=false
 
-# create folders recursively if they don't exist already
-sudo mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
-sudo chown pi:pi -R $HOME/$DEXTER
-cd $HOME/$DEXTER/$LIB/$DEXTER
+  # the following 2 options can be used together
+  updatedebs=false
+  installdebs=false
+
+  # the following option tells which branch has to be used
+  selectedbranch="master" # set to master by default
+
+  # iterate through bash arguments
+  for i; do
+    case "$i" in
+      --install-python-package)
+        installpythonpkg=true
+        ;;
+      --user-local)
+        userlocal=true
+        systemwide=false
+        ;;
+      --env-local)
+        envlocal=true
+        systemwide=false
+        ;;
+      --system-wide)
+        ;;
+      --update-aptget)
+        updatedebs=true
+        ;;
+      --install-deb-deps)
+        installdebs=true
+        ;;
+      --use-python3-exe-too)
+        usepython3exec=true
+        ;;
+      develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
+        selectedbranch="$i"
+        ;;
+    esac
+  done
+
+
+  # exit if git is not installed
+  if [[ $installdebs = "false" ]]; then
+    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Use \"--install-deb-deps\" option. Aborting." >&2; exit 1; }
+  fi
+
+  # exit if python/python3 are not installed in the current environment
+  if [[ $installpythonpkg = "true" ]]; then
+    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Aborting." >&2; exit 2; }
+    if [[ $usepython3exec = "true" ]]; then
+      command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
+    fi
+  fi
+
+  pushd $HOME > /dev/null
+  result=${PWD##*/}
+
+  echo "Updating script_tools for $selectedbranch branch with the following options:"
+  echo "--install-python-package=$installpythonpkg"
+  echo "--system-wide=$systemwide"
+  echo "--user-local=$userlocal"
+  echo "--env-local=$envlocal"
+  echo "--use-python3-exe-too=$usepython3exec"
+  echo "--update-aptget=$updatedebs"
+  echo "--install-deb-deps=$installdebs"
+
+  # create folders recursively if they don't exist already
+  sudo mkdir -p $DEXTER_PATH
+  sudo chown pi:pi -R $HOME/$DEXTER
+  popd > /dev/null
+}
 
 ################################################
 ######## Installing Dependencies  ##############
 ################################################
 
-if [[ $updatedebs = "true" ]]; then
-  # bring in nodejs repo
+install_dependencies() {
+  if [[ $updatedebs = "true" ]]; then
+    # bring in nodejs repo
 
-  # to confirm nodejs is available for the given distribution
-  curl -sLf -o /dev/null "https://deb.nodesource.com/node_9.x/dists/$OS_CODENAME/Release"
-  ret_val=$?
-  if [[ $ret_val -e 0 ]]; then
-    # add gpg key for nodejs
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-    # add nodejs to apt-get source list
-    sudo sh -c "echo 'deb https://deb.nodesource.com/node_9.x $OS_CODENAME main' > /etc/apt/sources.list.d/nodesource.list"
-    sudo sh -c "echo 'deb-src https://deb.nodesource.com/node_9.x $OS_CODENAME main' >> /etc/apt/sources.list.d/nodesource.list"
-  else
-    echo "Couldn't add Nodejs repo because it's not available for this distribution"
+    # to confirm nodejs is available for the given distribution
+    curl -sLf -o /dev/null "https://deb.nodesource.com/node_9.x/dists/$OS_CODENAME/Release"
+    ret_val=$?
+    if [[ $ret_val -e 0 ]]; then
+      # add gpg key for nodejs
+      curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+      # add nodejs to apt-get source list
+      sudo sh -c "echo 'deb https://deb.nodesource.com/node_9.x $OS_CODENAME main' > /etc/apt/sources.list.d/nodesource.list"
+      sudo sh -c "echo 'deb-src https://deb.nodesource.com/node_9.x $OS_CODENAME main' >> /etc/apt/sources.list.d/nodesource.list"
+    else
+      echo "Couldn't add Nodejs repo because it's not available for this distribution"
+    fi
+
+    sudo apt-get update
   fi
-
-  sudo apt-get update
-fi
-[[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
+  [[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
+}
 
 ################################################
 ######## Cloning script_tools  #################
 ################################################
 
-# it's simpler and more reliable (for now) to just delete the repo and clone a new one
-# otherwise, we'd have to deal with all the intricacies of git
-sudo rm -rf $SCRIPT
-git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
-cd $SCRIPT
+clone_scriptools(){
+  # it's simpler and more reliable (for now) to just delete the repo and clone a new one
+  # otherwise, we'd have to deal with all the intricacies of git
+  sudo rm -rf $DEXTER_SCRIPT
+  pushd $DEXTER_PATH
+  git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
+  # useful in case we need it
+  current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
+  popd > /dev/null
+}
 
 ################################################
 ######## Installing Packages  ##################
 ################################################
 
-# useful in case we need it
-current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
+remove_python_packages() {
+  # the 1st and only argument
+  # takes the name of the package that needs to removed
+  rm -f $PIHOME/.pypaths
 
-if [[ $installpythonpkg = "true" ]]; then
-  [[ $systemwide = "true" ]] && sudo python setup.py install --force \
-              && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
-  [[ $userlocal = "true" ]] && python setup.py install --force --user \
-              && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user
-  [[ $envlocal = "true" ]] && python setup.py install --force \
-              && [[ $usepython3exec = "true" ]] && python3 setup.py install --force
-fi
+  # get absolute path to python package
+  # saves output to file because we want to have the syntax highlight working
+  # does this for both root and the current user because packages can be either system-wide or local
+  # later on the strings used with the python command can be put in just one string that gets used repeatedly
+  python -c "import pkgutil; import os; \
+              eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+  sudo python -c "import pkgutil; import os; \
+              eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+  if [[ $usepython3exec = "true" ]]; then
+    python3 -c "import pkgutil; import os; \
+                eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+    sudo python3 -c "import pkgutil; import os; \
+                eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+  fi
 
-popd > /dev/null
+  # removing eggs for $1 python package
+  # ideally, easy-install.pth needs to be adjusted too
+  # but pip seems to know how to handle missing packages, which is okay
+  while read path;
+  do
+    if [ ! -z "${path}" -a "${path}" != " " ]; then
+      echo "Removing ${path} egg"
+      sudo rm -f "${path}"
+    fi
+  done < $PIHOME/.pypaths
+}
+
+install_python_packages() {
+  [[ $systemwide = "true" ]] && sudo python setup.py install \
+              && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install
+  [[ $userlocal = "true" ]] && python setup.py install --user \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install --user
+  [[ $envlocal = "true" ]] && python setup.py install \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install
+}
+
+install_python_package() {
+  # remove the python package that resides in this repo
+  remove_python_packages $REPO_PACKAGE
+
+  # and install the new one
+  pushd $DEXTER_SCRIPT
+  install_python_packages
+  popd > /dev/null
+}
+
+################################################
+######## Aggregating all function calls ########
+################################################
+
+parse_cmdline_arguments
+install_dependencies
+clone_scriptools
+install_python_package
 
 exit 0

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -8,6 +8,48 @@
 #####################################################################
 #####################################################################
 
+# the following 3 options are mutually exclusive
+systemwide=true
+userlocal=false
+envlocal=false
+
+# the following 2 options can be used together
+updatedebs=false
+installdebs=false
+
+# the following option tells which branch has to be used
+selectedbranch="master" # set to master by default
+
+# iterate through bash arguments
+for i; do
+  case "$i" in
+    --user-local)
+      userlocal=true
+      systemwide=false
+      ;;
+    --env-local)
+      envlocal=true
+      systemwide=false
+      ;;
+    --system-wide)
+      ;;
+    --update-aptget)
+      updatedebs=true
+      ;;
+    --just-install-deb-deps)
+      installdebs=true
+      ;;
+    develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
+      selectedbranch="$i"
+      ;;
+  esac
+done
+
+echo $systemwide
+echo $userlocal
+echo $envlocal
+echo $selectedbranch
+
 DEXTER=Dexter
 LIB=lib
 SCRIPT=script_tools
@@ -41,17 +83,22 @@ cd $HOME/$DEXTER/$LIB/$DEXTER
 # check if /home/pi/Dexter/lib/script_tools exists
 # if yes refresh the folder
 # if not, clone the folder
-if [ ! -d $SCRIPT ] ; then
-    # clone the folder
-    git clone --quiet --depth=1 https://github.com/DexterInd/script_tools.git
-else
-    cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
-    git pull --quiet
-fi
+
+# it's simpler and more reliable (for now) to just delete the repo and clone a new one
+# otherwise, we'd have to deal with all the intricacies of git
+sudo rm -rf $SCRIPT
+git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
+
+# useful in case we need it
+current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 
 cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
-sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
-python setup.py install --force --user
-python3 setup.py install --force --user
+
+[[ $updatedebs ]] && sudo apt-get update
+[[ $installdebs ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
+
+[[ $systemwide ]] && sudo python setup.py install --force
+[[ $userlocal ]] && python setup.py install --force --user
+[[ $envlocal ]] && python setup.py install --force
 
 popd > /dev/null

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -127,8 +127,9 @@ clone_scriptools(){
   # it's simpler and more reliable (for now) to just delete the repo and clone a new one
   # otherwise, we'd have to deal with all the intricacies of git
   sudo rm -rf $DEXTER_SCRIPT
-  pushd $DEXTER_PATH
+  pushd $DEXTER_PATH > /dev/null
   git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
+  cd $DEXTER_SCRIPT
   # useful in case we need it
   current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
   popd > /dev/null
@@ -188,7 +189,7 @@ install_python_package() {
   remove_python_packages $REPO_PACKAGE
 
   # and install the new one
-  pushd $DEXTER_SCRIPT
+  pushd $DEXTER_SCRIPT > /dev/null
   install_python_packages
   popd > /dev/null
 }

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -10,6 +10,7 @@
 
 command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Aborting." >&2; exit 1; }
 command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Aborting." >&2; exit 2; }
+command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Aborting." >&2; exit 3; }
 
 # the following 3 options are mutually exclusive
 systemwide=true
@@ -53,7 +54,7 @@ for i; do
 done
 
 if [[ $usepython3exec = "true" ]]; then
-  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
+  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 4; }
 fi
 
 DEXTER=Dexter
@@ -67,16 +68,16 @@ echo "Current directory is \"$result\""
 
 # create folders recursively if they don't exist already
 mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
+cd $HOME/$DEXTER/$LIB/$DEXTER
 
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git
 sudo rm -rf $SCRIPT
 git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
+cd $SCRIPT
 
 # useful in case we need it
 current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
-
-cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
 
 [[ $updatedebs = "true" ]] && sudo apt-get update
 [[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -57,7 +57,7 @@ done
 
 # exit if git is not installed
 if [[ $installdebs = "false" ]]; then
-  command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Use \"--install-deb-deps\" option. Aborting." >&2; exit 1; }
+  command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Use \"--install-deb-deps\" option. Aborting." >&2; exit 1; }
 fi
 
 # exit if python/python3 are not installed in the current environment

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -4,6 +4,8 @@
 ######## Parsing Command Line Arguments ########
 ################################################
 
+OS_CODENAME=$(lsb_release --codename --short)
+
 # the following option is required should the python package be installed
 # by default, the python package are not installed
 installpythonpkg=false
@@ -91,7 +93,24 @@ cd $HOME/$DEXTER/$LIB/$DEXTER
 ######## Installing Dependencies  ##############
 ################################################
 
-[[ $updatedebs = "true" ]] && sudo apt-get update
+if [[ $updatedebs = "true" ]]; then
+  # bring in nodejs repo
+
+  # to confirm nodejs is available for the given distribution
+  curl -sLf -o /dev/null "https://deb.nodesource.com/node_9.x/dists/$OS_CODENAME/Release"
+  ret_val=$?
+  if [[ $ret_val -e 0 ]]; then
+    # add gpg key for nodejs
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+    # add nodejs to apt-get source list
+    sudo sh -c "echo 'deb https://deb.nodesource.com/node_9.x $OS_CODENAME main' > /etc/apt/sources.list.d/nodesource.list"
+    sudo sh -c "echo 'deb-src https://deb.nodesource.com/node_9.x $OS_CODENAME main' >> /etc/apt/sources.list.d/nodesource.list"
+  else
+    echo "Couldn't add Nodejs repo because it's not available for this distribution"
+  fi
+
+  sudo apt-get update
+fi
 [[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
 
 ################################################

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -125,7 +125,7 @@ install_dependencies() {
 
     sudo apt-get update
   fi
-  [[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
+  [[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools python-pip python3-pip libffi-dev -y
 }
 
 ################################################

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -88,7 +88,7 @@ cd $SCRIPT
 current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 
 [[ $updatedebs = "true" ]] && sudo apt-get update
-[[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
+[[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
 
 if [[ $installpythonpkg = "true" ]]; then
   [[ $systemwide = "true" ]] && sudo python setup.py install --force \

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -16,7 +16,7 @@ REPO_PACKAGE=dexter-autodetection-and-i2c-mutex
 check_if_run_with_pi() {
   ## if not running with the pi user then exit
   if [ $(id -ur) -ne $(id -ur pi) ]; then
-    echo "GoPiGo3 installer script must be run with \"pi\" user. Exiting."
+    echo "script_tools installer script must be run with \"pi\" user. Exiting."
     exit 4
   fi
 }

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -91,7 +91,7 @@ current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 [[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
 
 if [[ $installpythonpkg = "true" ]]; then
-  [[ $systemwide = "true" ]] && sudo python setup.py install --force > \
+  [[ $systemwide = "true" ]] && sudo python setup.py install --force \
               && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
   [[ $userlocal = "true" ]] && python setup.py install --force --user \
               && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -8,7 +8,7 @@ OS_CODENAME=$(lsb_release --codename --short)
 PIHOME=/home/pi
 DEXTER=Dexter
 LIB=lib
-DEXTER_PATH=$HOME/$DEXTER/$LIB/$DEXTER
+DEXTER_PATH=$PIHOME/$DEXTER/$LIB/$DEXTER
 DEXTER_SCRIPT=$DEXTER_PATH/script_tools
 REPO_PACKAGE=dexter-autodetection-and-i2c-mutex
 
@@ -75,7 +75,7 @@ parse_cmdline_arguments() {
     fi
   fi
 
-  pushd $HOME > /dev/null
+  pushd $PIHOME > /dev/null
   result=${PWD##*/}
 
   echo "Updating script_tools for $selectedbranch branch with the following options:"
@@ -89,7 +89,7 @@ parse_cmdline_arguments() {
 
   # create folders recursively if they don't exist already
   sudo mkdir -p $DEXTER_PATH
-  sudo chown pi:pi -R $HOME/$DEXTER
+  sudo chown pi:pi -R $PIHOME/$DEXTER
   popd > /dev/null
 }
 
@@ -104,7 +104,7 @@ install_dependencies() {
     # to confirm nodejs is available for the given distribution
     curl -sLf -o /dev/null "https://deb.nodesource.com/node_9.x/dists/$OS_CODENAME/Release"
     ret_val=$?
-    if [[ $ret_val -e 0 ]]; then
+    if [[ $ret_val -eq 0 ]]; then
       # add gpg key for nodejs
       curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
       # add nodejs to apt-get source list

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -185,13 +185,15 @@ install_python_packages() {
 }
 
 install_python_package() {
-  # remove the python package that resides in this repo
-  remove_python_packages $REPO_PACKAGE
+  if [[ $installpythonpkg = "true" ]]; then
+    # remove the python package that resides in this repo
+    remove_python_packages $REPO_PACKAGE
 
-  # and install the new one
-  pushd $DEXTER_SCRIPT > /dev/null
-  install_python_packages
-  popd > /dev/null
+    # and install the new one
+    pushd $DEXTER_SCRIPT > /dev/null
+    install_python_packages
+    popd > /dev/null
+  fi
 }
 
 ################################################

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -1,6 +1,3 @@
-# exit if git is not installed
-command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Aborting." >&2; exit 1; }
-
 # the following option is required should the python package be installed
 # by default, the python package are not installed
 installpythonpkg=false
@@ -49,12 +46,17 @@ for i; do
   esac
 done
 
-# exit if python/python3/pip are not installed in the current environment
+
+# exit if git is not installed
+if [[ $installdebs = "false" ]]; then
+  command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Use \"--install-deb-deps\" option. Aborting." >&2; exit 1; }
+fi
+
+# exit if python/python3 are not installed in the current environment
 if [[ $installpythonpkg = "true" ]]; then
   command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Aborting." >&2; exit 2; }
-  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Aborting." >&2; exit 3; }
   if [[ $usepython3exec = "true" ]]; then
-    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 4; }
+    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Aborting." >&2; exit 3; }
   fi
 fi
 
@@ -78,6 +80,9 @@ echo "--install-deb-deps=$installdebs"
 mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
 cd $HOME/$DEXTER/$LIB/$DEXTER
 
+[[ $updatedebs = "true" ]] && sudo apt-get update
+[[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
+
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git
 sudo rm -rf $SCRIPT
@@ -86,9 +91,6 @@ cd $SCRIPT
 
 # useful in case we need it
 current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
-
-[[ $updatedebs = "true" ]] && sudo apt-get update
-[[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
 
 if [[ $installpythonpkg = "true" ]]; then
   [[ $systemwide = "true" ]] && sudo python setup.py install --force \

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -1,13 +1,4 @@
-#! /bin/bash
-#####################################################################
-#####################################################################
-#
-# to install:
-# curl --silent https://raw.githubusercontent.com/DexterInd/script_tools/master/install_script_tools.sh | bash
-#
-#####################################################################
-#####################################################################
-
+# exit if git is not installed
 command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Aborting." >&2; exit 1; }
 
 # the following option is required should the python package be installed
@@ -74,7 +65,14 @@ SCRIPT=script_tools
 pushd $HOME > /dev/null
 result=${PWD##*/}
 
-echo "Current directory is \"$result\""
+echo "Updating script_tools for $selectedbranch branch with the following options:"
+echo "--install-python-package=$installpythonpkg"
+echo "--system-wide=$systemwide"
+echo "--user-local=$userlocal"
+echo "--env-local=$envlocal"
+echo "--use-python3-exe-too=$usepython3exec"
+echo "--update-aptget=$updatedebs"
+echo "--install-deb-deps=$installdebs"
 
 # create folders recursively if they don't exist already
 mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
@@ -93,7 +91,7 @@ current_branch=$(git branch | grep \* | cut -d ' ' -f2-)
 [[ $installdebs = "true" ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
 
 if [[ $installpythonpkg = "true" ]]; then
-  [[ $systemwide = "true" ]] && sudo python setup.py install --force \
+  [[ $systemwide = "true" ]] && sudo python setup.py install --force > \
               && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
   [[ $userlocal = "true" ]] && python setup.py install --force --user \
               && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -102,3 +102,5 @@ if [[ $installpythonpkg = "true" ]]; then
 fi
 
 popd > /dev/null
+
+exit 0

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -12,6 +12,7 @@
 systemwide=true
 userlocal=false
 envlocal=false
+usepython3exec=false
 
 # the following 2 options can be used together
 updatedebs=false
@@ -38,6 +39,9 @@ for i; do
       ;;
     --install-deb-deps)
       installdebs=true
+      ;;
+    --use-python3-command-too)
+      usepython3exec=true
       ;;
     develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
       selectedbranch="$i"
@@ -74,9 +78,11 @@ cd $HOME/$DEXTER/$LIB/$DEXTER/$SCRIPT
 
 [[ $updatedebs ]] && sudo apt-get update
 [[ $installdebs ]] && sudo apt-get install build-essential libi2c-dev i2c-tools python-dev libffi-dev -y
-
-[[ $systemwide ]] && sudo python setup.py install --force
-[[ $userlocal ]] && python setup.py install --force --user
-[[ $envlocal ]] && python setup.py install --force
+[[ $systemwide ]] && sudo python setup.py install --force \
+                  && [[ $usepython3exec ]] && sudo python3 setup.py install --force
+[[ $userlocal ]] && python setup.py install --force --user \
+                  && [[ $usepython3exec ]] && python3 setup.py install --force --user
+[[ $envlocal ]] && python setup.py install --force \
+                  && [[ $usepython3exec ]] && python3 setup.py install --force
 
 popd > /dev/null

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -77,7 +77,8 @@ echo "--update-aptget=$updatedebs"
 echo "--install-deb-deps=$installdebs"
 
 # create folders recursively if they don't exist already
-mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
+sudo mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
+sudo chown pi:pi -R $HOME/$DEXTER
 cd $HOME/$DEXTER/$LIB/$DEXTER
 
 [[ $updatedebs = "true" ]] && sudo apt-get update

--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -1,3 +1,9 @@
+#! /bin/bash
+
+################################################
+######## Parsing Command Line Arguments ########
+################################################
+
 # the following option is required should the python package be installed
 # by default, the python package are not installed
 installpythonpkg=false
@@ -81,14 +87,26 @@ sudo mkdir -p $HOME/$DEXTER/$LIB/$DEXTER
 sudo chown pi:pi -R $HOME/$DEXTER
 cd $HOME/$DEXTER/$LIB/$DEXTER
 
+################################################
+######## Installing Dependencies  ##############
+################################################
+
 [[ $updatedebs = "true" ]] && sudo apt-get update
 [[ $installdebs = "true" ]] && sudo apt-get install git build-essential libi2c-dev i2c-tools python-dev python3-dev python-setuptools python3-setuptools libffi-dev -y
+
+################################################
+######## Cloning script_tools  #################
+################################################
 
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git
 sudo rm -rf $SCRIPT
 git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/script_tools.git
 cd $SCRIPT
+
+################################################
+######## Installing Packages  ##################
+################################################
 
 # useful in case we need it
 current_branch=$(git branch | grep \* | cut -d ' ' -f2-)


### PR DESCRIPTION
This has been tested thoroughly and I'm sure this can be the final version of `script_tools`. The changes that I have brought into this PR can then be used with other repositories too.

Once this gets pushed to the `develop` branch, I should be merging the `master` branch without another PR, so we can cut some time. There's literally no difference between `master` and `develop` at this moment **and** this is **backwards compatible with the "old" installation script**.

Also, in order to have a ride with this new install script, you can `curl` this file:
https://raw.githubusercontent.com/RobertLucian/script_tools/feature/arg-based-installation/install_script_tools.sh 

I have copied a part of README so you can give it a read and understand how you can install script_tools.

# Installing

The most basic command used for updating/installing script_tools can be:
```
curl -kL dexterindustries.com/update_tools | bash -s --install-python-package
```

The above command installs the python package with user-level permissions on the system-wide environment - which does not work on most distributions unless a virtual environment is used.

### Python Package Options

In order to **enable the installation of the python package**, option `--install-python-package` is a must. This holds true for both python executables (`python` and `python3`) in case you are wondering if this is for `--use-python3-exe-too`.

The options for the python package that can be appended to this command are (all these 3 options **are mutually exclusive**):

* `--system-wide` - uses `sudo` for installing the python package system-wide.

* `--user-local` - for installing the python package in the home directory of the given user, where no special write/read/execute permissions are required.

* `--env-local` - for installing the python package system-wide, but without any special write/read/execute permissions - in order to use this you'll need a virtual environment.

On different distributions, Python 3 can only be used with `python3` executable, in which case option `--use-python3-exe-too` is required.

### Apt-Get Package Options

The options that can be added for apt-get/deb packages are:

* `update-aptget` - will run `sudo apt-get update`.
* `--install-deb-debs` - will run the `sudo apt-get install [dependencies]` command which installs the general dependencies.

### Selecting a Branch/Tag to Checkout

Also, to this install script you can specify a tag or a branch you want to use, just by passing the name of it. Branches must have this format (`master`, `develop`, `feature/*`, `hotfix/*`, `fix/`) whereas tags can have this format (`v*` or `DexterOS*`).
**By default, `master` branch is pulled.**

# Installation Examples

To install the python package with `sudo` and skip installing apt-get packages (though in this case `--system-wide` can be omitted because it's turned on by default):
```
curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --system-wide
```

To install the python package locally in the home directory and skip installing apt-get packages:
```
curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --user-local
```

To install the python package locally in the home directory, run apt-get update and install apt-get dependencies:
```
curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --user-local --update-aptget --install-deb-deps
```

To only install `script_tools` at the designated location without installing the python package and take the version that's pointed by tag `DexterOS2.0`:
```
curl -kL dexterindustries.com/update_tools | bash -s DexterOS2.0
```
Or if we want the version that's on `develop` branch we can do:
```
curl -kL dexterindustries.com/update_tools | bash -s develop
```
To install packages for `python` and `python3` executables/commands, you can do this:
```
curl -kL dexterindustries.com/update_tools | bash -s --install-python-package --use-python3-exe-too
```
