### PR TITLE
temporarily disable check on pi user

### DIFF
--- a/install_script_tools.sh
+++ b/install_script_tools.sh
@@ -211,7 +211,8 @@ install_python_package() {
 ######## Aggregating all function calls ########
 ################################################
 
-check_if_run_with_pi
+# wait on this check until all scripts are ready
+#check_if_run_with_pi
 parse_cmdline_arguments "$@"
 install_dependencies
 clone_scriptools


### PR DESCRIPTION
While our scripts still require sudo, and we still have all our curl lines use sudo, I've temporarily disabled the check on the pi user.